### PR TITLE
upgrade tools to 0.21.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/josebalius/exhauststruct
 
 go 1.18
 
-require golang.org/x/tools v0.2.0
+require golang.org/x/tools v0.21.0
 
 require (
-	golang.org/x/mod v0.6.0 // indirect
-	golang.org/x/sys v0.1.0 // indirect
+	golang.org/x/mod v0.17.0 // indirect
+	golang.org/x/sync v0.7.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
-golang.org/x/mod v0.6.0 h1:b9gGHsz9/HhJ3HF5DHQytPpuwocVTChQJK3AvoLRD5I=
-golang.org/x/mod v0.6.0/go.mod h1:4mET923SAdbXp2ki8ey+zGs1SLqsuM2Y0uvdZR/fUNI=
-golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
-golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.2.0 h1:G6AHpWxTMGY1KyEYoAQ5WTtIekUUvDNjan3ugu60JvE=
-golang.org/x/tools v0.2.0/go.mod h1:y4OqIKeOV/fWJetJ8bXPU1sEVniLMIyDAZWeHdV+NTA=
+golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
+golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/tools v0.17.0 h1:FvmRgNOcs3kOa+T20R1uhfP9F6HgG2mfxDv1vrx1Htc=
+golang.org/x/tools v0.17.0/go.mod h1:xsh6VxdV005rRVaS6SSAf9oiAqljS7UZUacMZ8Bnsps=
+golang.org/x/tools v0.21.0 h1:qc0xYgIbsSDt9EyWz05J5wfa7LOVW0YTLOXrqdLAWIw=
+golang.org/x/tools v0.21.0/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=


### PR DESCRIPTION
I ran into this error when attempting to run `golangci-lint` in Conduit. Upgrading golang-tools seem to fix it.
```
@mkdinh ➜ /workspaces/conduit $ /go/bin/exhauststruct ./...
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x592dcf]

goroutine 84 [running]:
go/types.(*Checker).handleBailout(0xc0009de200, 0xc0009ffc10)
        /usr/local/go/src/go/types/check.go:367 +0x88
panic({0x713140?, 0x99ab50?})
        /usr/local/go/src/runtime/panic.go:770 +0x132
go/types.(*StdSizes).Sizeof(0x0, {0x7dfc98, 0x99e6a0})
        /usr/local/go/src/go/types/sizes.go:228 +0x30f
go/types.(*Config).sizeof(...)
        /usr/local/go/src/go/types/sizes.go:333
go/types.representableConst.func1({0x7dfc98?, 0x99e6a0?})
        /usr/local/go/src/go/types/const.go:76 +0x9e
go/types.representableConst({0x7e1aa0, 0x9933e0}, 0xc0009de200, 0x99e6a0, 0xc0009fc748)
        /usr/local/go/src/go/types/const.go:92 +0x192
go/types.(*Checker).representation(0xc0009de200, 0xc001036ac0, 0x99e6a0)
        /usr/local/go/src/go/types/const.go:256 +0x65
go/types.(*Checker).implicitTypeAndValue(0xc0009de200, 0xc001036ac0, {0x7dfc98, 0x99e6a0})
        /usr/local/go/src/go/types/expr.go:375 +0x2d7
go/types.(*Checker).convertUntyped(0xc0009de200, 0xc001036ac0, {0x7dfc98, 0x99e6a0})
        /usr/local/go/src/go/types/const.go:289 +0x3f
go/types.(*Checker).isValidIndex(0xc0009de200, 0xc001036ac0, 0x34, {0x765287, 0x5}, 0x0)
        /usr/local/go/src/go/types/index.go:384 +0x86
go/types.(*Checker).index(0xc0009de200, {0x7e1550, 0xc00070b5a0}, 0xffffffffffffffff)
        /usr/local/go/src/go/types/index.go:355 +0xc6
go/types.(*Checker).builtin(0xc0009de200, 0xc001036a40, 0xc00023a9c0, 0x9)
        /usr/local/go/src/go/types/builtins.go:517 +0x62f6
go/types.(*Checker).callExpr(0xc0009de200, 0xc001036a40, 0xc00023a9c0)
        /usr/local/go/src/go/types/call.go:236 +0xf85
go/types.(*Checker).exprInternal(0xc0009de200, 0x0, 0xc001036a40, {0x7e1610, 0xc00023a9c0}, {0x0, 0x0})
        /usr/local/go/src/go/types/expr.go:1374 +0xf8
go/types.(*Checker).rawExpr(0xc0009de200, 0x0, 0xc001036a40, {0x7e1610?, 0xc00023a9c0?}, {0x0?, 0x0?}, 0x0)
        /usr/local/go/src/go/types/expr.go:979 +0x19e
go/types.(*Checker).multiExpr(0xc0009de200, {0x7e1610, 0xc00023a9c0}, 0x0)
        /usr/local/go/src/go/types/expr.go:1532 +0x79
go/types.(*Checker).initVars(0xc0009de200, {0xc000126918, 0x1, 0x1}, {0xc000378780, 0x1, 0x1}, {0x0, 0x0})
        /usr/local/go/src/go/types/assignments.go:408 +0x129
go/types.(*Checker).shortVarDecl(0xc0009de200, {0x7deb60, 0xc001034048}, {0xc000378760, 0x1, 0xc0009f7b38?}, {0xc000378780, 0x1, 0x1})
        /usr/local/go/src/go/types/assignments.go:556 +0x8f0
go/types.(*Checker).stmt(0xc0009de200, 0x0, {0x7e1250, 0xc00023aa80})
        /usr/local/go/src/go/types/stmt.go:473 +0x15ff
go/types.(*Checker).stmtList(0xc0009de200, 0x0, {0xc00023ac40?, 0x0?, 0x0?})
        /usr/local/go/src/go/types/stmt.go:121 +0x85
go/types.(*Checker).funcBody(0xc0009de200, 0x7e0620?, {0xc00099c1b0?, 0xc000379510?}, 0xc000274d40, 0xc0009b0d50, {0x0?, 0x0?})
        /usr/local/go/src/go/types/stmt.go:41 +0x331
go/types.(*Checker).funcDecl.func1()
        /usr/local/go/src/go/types/decl.go:852 +0x3a
go/types.(*Checker).processDelayed(0xc0009de200, 0x0)
        /usr/local/go/src/go/types/check.go:467 +0x162
go/types.(*Checker).checkFiles(0xc0009de200, {0xc000126408, 0x1, 0x1})
        /usr/local/go/src/go/types/check.go:411 +0x1cc
go/types.(*Checker).Files(...)
        /usr/local/go/src/go/types/check.go:372
golang.org/x/tools/go/packages.(*loader).loadPackage(0xc00019c000, 0xc00083bc20)
        /go/pkg/mod/golang.org/x/tools@v0.2.0/go/packages/packages.go:1037 +0x932
golang.org/x/tools/go/packages.(*loader).loadRecursive.func1()
        /go/pkg/mod/golang.org/x/tools@v0.2.0/go/packages/packages.go:847 +0x1a9
sync.(*Once).doSlow(0x0?, 0x0?)
        /usr/local/go/src/sync/once.go:74 +0xc2
sync.(*Once).Do(...)
        /usr/local/go/src/sync/once.go:65
golang.org/x/tools/go/packages.(*loader).loadRecursive(0x0?, 0x0?)
        /go/pkg/mod/golang.org/x/tools@v0.2.0/go/packages/packages.go:835 +0x4a
golang.org/x/tools/go/packages.(*loader).refine.func2(0x0?)
        /go/pkg/mod/golang.org/x/tools@v0.2.0/go/packages/packages.go:770 +0x26
created by golang.org/x/tools/go/packages.(*loader).refine in goroutine 1
```